### PR TITLE
adding absolute path as 3rd argument

### DIFF
--- a/lib/each-module.js
+++ b/lib/each-module.js
@@ -26,7 +26,7 @@ function assertArgIsFunction (name, val) {
 
 function performGlob (path, fn) {
     glob.sync(getGlobPattern(resolvePath(path))).forEach(function (file) {
-        fn(getModuleName(path, file), require(file));
+        fn(getModuleName(path, file), require(file), file);
     });
 }
 

--- a/test/each-module.js
+++ b/test/each-module.js
@@ -81,17 +81,28 @@ describe('each-module', function () {
     it('should call `fn` for each file in the directory', function () {
         var fn = sinon.spy();
         eachModule('foo', fn);
+
         assert.strictEqual(fn.callCount, 5);
+
         assert.strictEqual(fn.getCall(0).args[0], 'bar');
         assert.strictEqual(fn.getCall(0).args[1], mods.bar);
+        assert.strictEqual(fn.getCall(0).args[2], 'foo/bar.js');
+
         assert.strictEqual(fn.getCall(1).args[0], 'baz');
         assert.strictEqual(fn.getCall(1).args[1], mods.baz);
+        assert.strictEqual(fn.getCall(1).args[2], 'foo/baz.js');
+
         assert.strictEqual(fn.getCall(2).args[0], 'qux/qux');
         assert.strictEqual(fn.getCall(2).args[1], mods.qux);
+        assert.strictEqual(fn.getCall(2).args[2], 'foo/qux/qux.js');
+
         assert.strictEqual(fn.getCall(3).args[0], 'hello');
         assert.strictEqual(fn.getCall(3).args[1], mods.hello);
+        assert.strictEqual(fn.getCall(3).args[2], 'foo/hello.coffee');
+
         assert.strictEqual(fn.getCall(4).args[0], 'data');
         assert.strictEqual(fn.getCall(4).args[1], mods.data);
+        assert.strictEqual(fn.getCall(4).args[2], 'foo/data.json');
     });
 
 });


### PR DESCRIPTION
This adds a 3rd argument to the handler fn that contains the absolute path. This is useful in cases where you are needing to write to the files you are iterating: (or just want to know the extension of the input file)
- foo/index.js
- foo/index.json
- foo/index.coffee

``` js
each('./foo', function (base, mod, file) {
  // 0 => 'index', {}, '/path/to/foo/index.js'
  // 1 => 'index', {}, '/path/to/foo/index.json'
  // 2 => 'index', {}, '/path/to/foo/index.coffee'
});
```
